### PR TITLE
Fix: allow arrays to only have 1 element

### DIFF
--- a/json.janet
+++ b/json.janet
@@ -45,7 +45,7 @@
       :object (/ (* "{" (+ :members) "}") ,struct)
       :members (+ (* (some (* :member ",")) :member) :member)
       :member (* :s* (/ :string ,keyword) :s* ":" :element)
-      :elements (+ (* (some (* :element ",")) :element))
+      :elements (+ (* (some (* :element ",")) :element) :element)
       :array (group (* "[" (+ :elements :s*) "]"))
       # After validating, we can trust builtin parse to return a floating point number
       #


### PR DESCRIPTION
The current decoder only allows 0, 2, or more elements in an array. This change makes it accept a single element.